### PR TITLE
[#41] Fix to "Make placement of external JS even if merge is disabled"

### DIFF
--- a/plugins/system/jbetolo/jbetolo.php
+++ b/plugins/system/jbetolo/jbetolo.php
@@ -512,27 +512,25 @@ class plgSystemJBetolo extends JPlugin {
                 }
 
                 // collect resources to be excluded from merging
-                if ($merge) {
-                        $excluded = self::param($type . '_merge_exclude');
+                $excluded = self::param($type . '_merge_exclude');
 
-                        if (isset($excluded) && $excluded) {
-                                $excluded = @explode(',', $excluded);
-                        } else {
-                                $excluded = array();
-                        }
+                if (isset($excluded) && $excluded) {
+                        $excluded = @explode(',', $excluded);
+                } else {
+                        $excluded = array();
+                }
 
-                        $excluded = array_merge($excluded, self::$predefinedExclude[$type], $excludedSrcs);
+                $excluded = array_merge($excluded, self::$predefinedExclude[$type], $excludedSrcs);
 
-                        // Gzip operates at file level, therefore if a file is indicated to be non-gzipped
-                        // and gzipping of merged file is enabled then we need to exclude it
-                        // (the analogus doesn't apply for minify as merged file can contain a mix of
-                        //  minified and non-minified code)
-                        $abs_excl = self::param('gzip_exclude');
+                // Gzip operates at file level, therefore if a file is indicated to be non-gzipped
+                // and gzipping of merged file is enabled then we need to exclude it
+                // (the analogus doesn't apply for minify as merged file can contain a mix of
+                //  minified and non-minified code)
+                $abs_excl = self::param('gzip_exclude');
 
-                        if ($abs_excl && $gzip) {
-                                $abs_excl = explode(',', $abs_excl);
-                                $excluded = array_merge($excluded, $abs_excl);
-                        }
+                if ($abs_excl && $gzip) {
+                        $abs_excl = explode(',', $abs_excl);
+                        $excluded = array_merge($excluded, $abs_excl);
                 }
 
                 // find all resources
@@ -582,7 +580,7 @@ class plgSystemJBetolo extends JPlugin {
                                 if ($merge) {
                                         $shouldIgnore = jbetoloFileHelper::isFileExcluded($src, $excluded);
                                 } else {
-                                        $shouldIgnore = type == 'css' || self::param('js_placement') == 1;
+                                        $shouldIgnore = type == 'css' || self::param('js_placement') == 1 || jbetoloFileHelper::isFileExcluded($src, $excluded);
                                 }
 
                                 if ($type == 'css') {

--- a/plugins/system/jbetolo/jbetolo.php
+++ b/plugins/system/jbetolo/jbetolo.php
@@ -582,7 +582,7 @@ class plgSystemJBetolo extends JPlugin {
                                 if ($merge) {
                                         $shouldIgnore = jbetoloFileHelper::isFileExcluded($src, $excluded);
                                 } else {
-                                        $shouldIgnore = true;
+                                        $shouldIgnore = type == 'css' || self::param('js_placement') == 1;
                                 }
 
                                 if ($type == 'css') {

--- a/plugins/system/jbetolo/jbetolo.xml
+++ b/plugins/system/jbetolo/jbetolo.xml
@@ -168,6 +168,7 @@
                                 <field name="js_jquery" type="text" default="jquery.js" label="PLG_JBETOLO_JQUERY_FILE_NAME" />
                                 <field name="spacer_js_placement" type="spacer" default="" label="PLG_JBETOLO_JSPLACE" />
                                 <field name="js_placement" type="list" default="2" label="PLG_JBETOLO_JS_PLACEMENT_LBL" description="PLG_JBETOLO_JS_PLACEMENT_DESC">
+                                        <option value="1">PLG_JBETOLO_DONT_MOVE</option>
                                         <option value="2">PLG_JBETOLO_FIRST_HEAD</option>
                                         <option value="3">PLG_JBETOLO_LAST_HEAD</option>
                                         <option value="4">PLG_JBETOLO_LAST_BODY</option>

--- a/plugins/system/jbetolo/jbetolo/helper.php
+++ b/plugins/system/jbetolo/jbetolo/helper.php
@@ -2293,6 +2293,18 @@ class jbetoloFileHelper {
                                         }
                                 }
                         }
+                        else if ($type == 'js') {
+                                $js_imports[] = "";
+                                foreach ($_src_files as $src_file)
+                                        $js_imports[] = '<script type="text/javascript" src="' . $src_file . '"></script>';
+                                $js_imports[] = "";
+                                jbetoloHelper::replaceTags(
+                                        $body,
+                                        $replace_tags['js'],
+                                        "",
+                                        $indexes['js']
+                                );
+                        }
 
                         $gzip_excluded = plgSystemJBetolo::param($type . '_gzip_excluded');
                         $minify_excluded = plgSystemJBetolo::param($type . '_minify_excluded');


### PR DESCRIPTION
Updates to fix the issue "Make placement of external resources independent of merge #41", enabling the option "Placement of external JavaScript files" even when the option "Merge" is set to "No".
