### PR TITLE
Fixed 'pingUrls' in Joomla 3.x.

### DIFF
--- a/plugins/system/jbetolo/jbetolo/helper.php
+++ b/plugins/system/jbetolo/jbetolo/helper.php
@@ -166,7 +166,7 @@ class jbetoloHelper {
          */
         public static function pingUrls($deep = false) {
                 $db = JFactory::getDBO();
-                $query = 'SELECT '.$db->nameQuote('id').', link, '.$db->nameQuote('type').' FROM #__menu WHERE published = 1';
+                $query = 'SELECT '.$db->quoteName('id').', link, '.$db->quoteName('type').' FROM #__menu WHERE published = 1';
 
                 $db->setQuery($query);
 


### PR DESCRIPTION
The use of 'nameQuote' was causing the query to fail with syntax error.
Since Joomla 1.6.x nameQuote has been deprecated. In Joomla 3.x it is no longer available.
